### PR TITLE
add click/mouseenter/mouseleave events for qtip2 tooltips element

### DIFF
--- a/utils/hints.js
+++ b/utils/hints.js
@@ -54,12 +54,14 @@ $(Khan).bind("newProblem", function() {
                 at: "top center"
             },
             show: {
+                event: 'click mouseenter',
                 delay: 200,
                 effect: {
                     length: 0
                 }
             },
             hide: {
+                event: 'click mouseleave',
                 delay: 0
             }
         });


### PR DESCRIPTION
ipad 之所以 「可接受格式」的 tooltips 出問題是因為沒有設定對應的 event
我推測當初導入 qtip2 這個 lib 時，應該沒有考慮 ipad 的 case ...

加上 click / mouseenter / mouseleave 的 events 後，mobile 裝置就會 work 了
（目前測試 iphone6/ipad3 會 work）

＃目前我們使用的 qtip2 lib 版本為 2.0.0 preview，最新版到了 2.2.1
