### PR TITLE
add mathjax/2.1/extensions/TeX/enclose.js

### DIFF
--- a/utils/MathJax/2.1/extensions/TeX/enclose.js
+++ b/utils/MathJax/2.1/extensions/TeX/enclose.js
@@ -1,0 +1,15 @@
+/*
+ *  /MathJax/extensions/TeX/enclose.js
+ *  
+ *  Copyright (c) 2012 Design Science, Inc.
+ *
+ *  Part of the MathJax library.
+ *  See http://www.mathjax.org for details.
+ * 
+ *  Licensed under the Apache License, Version 2.0;
+ *  you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+MathJax.Extension["TeX/enclose"]={version:"2.1",ALLOWED:{arrow:1,color:1,mathcolor:1,background:1,mathbackground:1,padding:1,thickness:1}};MathJax.Hub.Register.StartupHook("TeX Jax Ready",function(){var c=MathJax.InputJax.TeX,a=MathJax.ElementJax.mml,b=MathJax.Extension["TeX/enclose"].ALLOWED;c.Definitions.Add({macros:{enclose:"Enclose"}},null,true);c.Parse.Augment({Enclose:function(g){var k=this.GetArgument(g),e=this.GetBrackets(g),j=this.ParseArg(g);var l={notation:k.replace(/,/g," ")};if(e){e=e.replace(/ /g,"").split(/,/);for(var h=0,d=e.length;h<d;h++){var f=e[h].split(/[:=]/);if(b[f[0]]){f[1]=f[1].replace(/^"(.*)"$/,"$1");if(f[1]==="true"){f[1]=true}if(f[1]==="false"){f[1]=false}l[f[0]]=f[1]}}}this.Push(a.menclose(j).With(l))}});MathJax.Hub.Startup.signal.Post("TeX enclose Ready")});MathJax.Ajax.loadComplete("[MathJax]/extensions/TeX/enclose.js");


### PR DESCRIPTION
新增 enclose.js version: 2.1
source code from:      https://cdnjs.com/libraries/mathjax/2.1
修復前台無法顯示長除法的問題

前台問題
原先有用到長除法提示的題目，在沒有enclose.js 套件情況下，點選提示，會出現 “你的網路連線可能太慢. 請重新整理或向均一回報問題.”
使用套件後，有用到長除法提示的題目，則可直接顯示該提示

ex:
http://www.junyiacademy.org/course-compare/math-grade-5-a/g05-m3nsj-a/e/menmt5a1?problem=5
算算看： 24 分 48 秒 ÷6=  分 秒。
按下該題提示並觀察

測試環境：
local端測試 < > 內為 branch 名稱 
junyiacademy ‹fix_mathjax_enclose_problem›
junyiacademy/khan-exercises ‹update_mathjax›

live server端測試: http://46.junyiacademy.appspot.com/course-compare/math-grade-5-a/g05-m3nsj-a/e/menmt5a1?problem=5

測試周邊相關題組：
因題組 < 時間的乘除計算：基礎 > 隱藏，url 需加設參數: ?problem=1  (數字為題目次序)
測試題目：1~10
測試方式：    
- 提示皆可顯示完成
- 未輸入答案，按下檢查，顯示“無法識別......”
- 輸入錯誤答案，顯示“答錯了.....”
- 輸入正確答案，顯示“答對了.....”，並確認點數有增加
- 按下我要告訴均一，彈出視窗“問題回報”，並勾選網頁連線緩慢 (請協助我們測試連線狀態！)，點擊開始測速，並確定可測速完成
- 確認未答對五題以上，不可升級
- 確認答對五題以上，可升級

如果按下提示，出現 error "你的網路連線可能太慢. 請重新整理或向均一回報問題."
請檢查 browser console，若出現以下訊息，則表示此題並非enclose.js 問題，與本次測試無關，可忽略此題
GET http://46.junyiacademy.appspot.com/khan-exercises/utils/MathJax/2.1/extensions/TeX/bbox.js 404 (Not Found)

測試其他類組題目
http://46.junyiacademy.appspot.com/course-compare/math-grade-5-a/g05-m3nsj-a/e/time_units_transformation_1
重複以上測項

確認答對五題以上，可升級