### PR TITLE
fix the axisArrow bug

### DIFF
--- a/utils/graphie.js
+++ b/utils/graphie.js
@@ -780,7 +780,7 @@
             if (axes) {
 
                 // this is a slight hack until <-> arrowheads work
-                if (axisArrows === "<->" || true) {
+                if (axisArrows === "<->" || axisArrows === true) {
                     this.style({
                         stroke: "#000000",
                         opacity: axisOpacity,


### PR DESCRIPTION
讓 axisArrow 的判斷式不會永遠都是 true
參考 KhanExercise 的 graphie.js 的修改
將後面的 true 改為 axisArrow === true