### PR TITLE
Remove exercise-answer-submit GA event

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -210,9 +210,7 @@ function newProblem(e, data) {
 }
 
 function handleCheckAnswer() {
-    if (!localMode){
-        Analytics.send_ga_event('exercise', 'submit', 'Exercise-Answer-Submit');
-    }
+
     return handleAttempt({skipped: false});
 }
 


### PR DESCRIPTION
This event would cause lots of useless log
to GA, later loged to bigQuery