### PR TITLE
delete the refresh dont worry wording

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -421,7 +421,7 @@ function handleAttempt(data) {
         $("#problem-and-answer").css("visibility", "hidden");
         $(Exercises).trigger("warning",
                 $._("這一個畫面過期了。請<a href='" + window.location.href +
-                    "'>重新整理</a>網頁。不用擔心，沒有損失進度。"
+                    "'>重新整理</a>網頁。"
                     )
         );
     });


### PR DESCRIPTION
學生抱怨，上面說請重新整理不會遺失進度，但重新整理後卻遺失進度。原本只是一個希望鼓勵使用者重新整理的語句，並沒有太多用途，因此將相關語句刪除。