### PR TITLE
Jump and end exam

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -75,7 +75,7 @@ function exercisePointCalculator(){
     var suggested_exercise_multiplier = 3;
     var incomplete_exercise_multiplier = 5;
     var limit_exercises = 150;
-
+    
     var points = 0;
     var offset = 0;
     var required_streak = min_streak_till_proficiency;
@@ -114,6 +114,7 @@ function exercisePointCalculator(){
 
 function problemTemplateRendered() {
     previewingItem = Exercises.previewingItem;
+    var first_time_skip = true;
     // Setup appropriate img URLs
     $("#issue-throbber").attr("src",
             Exercises.khanExercisesUrlBase + "css/images/throbber.gif");
@@ -133,15 +134,30 @@ function problemTemplateRendered() {
     $("#check-answer-button").click(handleCheckAnswer);
     $("#answerform").submit(handleCheckAnswer);
     $("#questionform").submit(handleCheckAnswer);
-    $("#skip-question-button").click(handleSkippedQuestion);
-    $("#jump-out").click(handleSkippedQuestion);
-    //$("#watch-report-directly").click(handleJumpToEnd);
-    function handlegotoReport(){
-        location.href = location.href.split('?')[0] + '?exam_list_report=1';
-    }
+    $("#skip-question-button").click(function(e) {
+        if(first_time_skip){
+        swal({
+            title:'<span style="font-size:20px;">小提醒：按下之後將無法再做答這題\n您確定要跳過嗎？</span>',
+            imageUrl: '/images/warn.svg',
+            imageWidth: 80,
+            width: 420,
+            showCancelButton: true,
+            confirmButtonText: '是',
+            confirmButtonColor: '#ff6756',
+            cancelButtonText: '否',
+        }).then(function () {
+            first_time_skip = false;
+            handleSkippedQuestion();
+        })
+        }else{
+            handleSkippedQuestion();
+        }
+        return false;
+    });
+
     $("#watch-report-directly").click(function(e) {
         swal({
-            title:'<span style="font-size:16px;">小提醒：按下之後將中止這份評量，如評量為老師指派的任務，將顯示您未完成任務。\n您確定要中止嗎？</span>',
+            title:'<span style="font-size:16px;">小提醒：按下之後將中止這份評量，如評量為老師指派的任務，將無法重新進行。\n您確定要中止嗎？</span>',
             imageUrl: '/images/warn.svg',
             imageWidth: 80,
             width: 420,
@@ -152,6 +168,7 @@ function problemTemplateRendered() {
         }).then(function () {
             handleJumpToEnd();
         })
+        return false;
     });    
     // Hint button
     $("#hint").click(onHintButtonClicked);
@@ -465,6 +482,7 @@ function handleAttempt(data) {
                         )
             );
         });
+        return false;
     }
     return [return_problemNum,attemptData];
 }
@@ -491,12 +509,13 @@ function handleStopExam(cards_to_be_skipped) {
         attemptDataList.push(attemptData[1]);
         problemNumList.push(attemptData[0]);
     }
-    // console.log(attemptDataList);
-    // if (Exercises.incompleteStack.length === 0){
-    //     problem_number = problem_number + 1;
-    // }
-    var requestUrl = "skip_problems/" + "0" + "/attempt";
-    request(requestUrl, {"list": JSON.stringify(attemptDataList), casing : "camel", "problem_list": JSON.stringify(problemNumList)}).fail(function(xhr) {
+
+    var requestUrl = "skip_problems/attempt";
+    request(requestUrl, {
+        "list": JSON.stringify(attemptDataList), 
+        casing : "camel", 
+        "problem_list": JSON.stringify(problemNumList)
+    }).fail(function(xhr) {
         // Alert any listeners of the error before reload
         $(Exercises).trigger("attemptError", {userExercise: userExercise});
 
@@ -554,7 +573,7 @@ function onHintShown(e, data) {
             if (hintCanVibration === true) {
                 hintCanVibration = false;
                 setTimeout(function() {
-                    $("#raise-handhint-button-container").effect("shake", {times: 3, distance: 5}, 480);
+                    $("#raise-hand-button-container").effect("shake", {times: 3, distance: 5}, 480);
                 },0);
             }
         }

--- a/interface.js
+++ b/interface.js
@@ -137,7 +137,7 @@ function problemTemplateRendered() {
     $("#jump-out").click(handleSkippedQuestion);
     $("#watch-report-directly").click(handlegotoReport);
     function handlegotoReport(){
-        location.href = location.href + '?exam_list_report=1';
+        location.href = location.href.split('?')[0] + '?exam_list_report=1';
     }    
     // Hint button
     $("#hint").click(onHintButtonClicked);
@@ -369,13 +369,12 @@ function handleAttempt(data) {
     }
     if(skipped){
          $(Exercises).trigger("skipAnswer", {
-        correct: score.correct,
+        correct: null,
         card: Exercises.currentCard,
 
         // Determine if this attempt qualifies as fast completion
         fast: !localMode && userExercise.secondsPerFastProblem >= timeTaken
-    });
-        
+    });      
     }
     else{
         $(Exercises).trigger("checkAnswer", {
@@ -392,8 +391,14 @@ function handleAttempt(data) {
     var stringifiedGuess = JSON.stringify(score.guess);
     var attemptData = null;
     if (!localMode) {
-        attemptData = buildAttemptData(
-            score.correct, ++attempts, stringifiedGuess, timeTaken, skipped);
+        if(skipped){
+            attemptData = buildAttemptData(
+                null, ++attempts, stringifiedGuess, timeTaken, skipped);
+        }else
+        {
+            attemptData = buildAttemptData(
+                score.correct, ++attempts, stringifiedGuess, timeTaken, skipped);
+        }
     }
     lastAttemptOrHint = curTime;
 
@@ -487,11 +492,10 @@ function onHintShown(e, data) {
             if (hintCanVibration === true) {
                 hintCanVibration = false;
                 setTimeout(function() {
-                    $("#raise-hand-button-container").effect("shake", {times: 3, distance: 5}, 480);
+                    $("#raise-handhint-button-container").effect("shake", {times: 3, distance: 5}, 480);
                 },0);
             }
         }
-
     }
 
 

--- a/interface.js
+++ b/interface.js
@@ -400,13 +400,7 @@ function handleAttempt(data) {
         updateHintButtonText();
     }
     if(skipped){
-         $(Exercises).trigger("skipAnswer", {
-        correct: null,
-        card: Exercises.currentCard,
-
-        // Determine if this attempt qualifies as fast completion
-        fast: !localMode && userExercise.secondsPerFastProblem >= timeTaken
-    });      
+        Exercises.renderProblemHistory();     
     }
     else{
         $(Exercises).trigger("checkAnswer", {

--- a/interface.js
+++ b/interface.js
@@ -429,7 +429,7 @@ function handleAttempt(data) {
         return false;
     }
     var requestUrl = "problems/" + problemNum + "/attempt";
-
+    return_problemNum = problemNum;
     if ((skipped || Exercises.examMode) && !Exercises.assessmentMode ) {
         // Skipping or examMode should pull up the next card immediately - but, if we're in
         // assessment mode, we don't know what the next card will be yet, so
@@ -466,7 +466,7 @@ function handleAttempt(data) {
             );
         });
     }
-    return [problemNum,attemptData];
+    return [return_problemNum,attemptData];
 }
 
 function onHintButtonClicked() {
@@ -485,18 +485,18 @@ function handleJumpToEnd(data){
 
 function handleStopExam(cards_to_be_skipped) {
     var attemptDataList = [];
-    problem_number = 0;
+    var problemNumList = [];
     for (var i = 0; i < cards_to_be_skipped ; i++){
         attemptData = handleAttempt({skipped: true});
         attemptDataList.push(attemptData[1]);
-        problem_number = attemptData[0];
+        problemNumList.push(attemptData[0]);
     }
-    console.log(attemptDataList);
-    if (Exercises.incompleteStack.length === 0){
-        problem_number = problem_number + 1;
-    }
-    var requestUrl = "skip_problems/" + (problem_number-cards_to_be_skipped) + "/attempt";
-    request(requestUrl, {"list": JSON.stringify(attemptDataList), casing : "camel"}).fail(function(xhr) {
+    // console.log(attemptDataList);
+    // if (Exercises.incompleteStack.length === 0){
+    //     problem_number = problem_number + 1;
+    // }
+    var requestUrl = "skip_problems/" + "0" + "/attempt";
+    request(requestUrl, {"list": JSON.stringify(attemptDataList), casing : "camel", "problem_list": JSON.stringify(problemNumList)}).fail(function(xhr) {
         // Alert any listeners of the error before reload
         $(Exercises).trigger("attemptError", {userExercise: userExercise});
 

--- a/interface.js
+++ b/interface.js
@@ -451,11 +451,7 @@ function handleAttempt(data) {
         // Skipping or examMode should pull up the next card immediately - but, if we're in
         // assessment mode, we don't know what the next card will be yet, so
         // wait for the special assessment mode triggers to fire instead.
-        if(skipped){
-            $(Exercises).trigger("jumptoNextProblem");
-        }else{
-            $(Exercises).trigger("gotoNextProblem");
-        }
+        $(Exercises).trigger("gotoNextProblem",[skipped]);
     }
     // Save the problem results to the server
     if(!skipped){

--- a/interface.js
+++ b/interface.js
@@ -576,7 +576,6 @@ function onHintShown(e, data) {
     lastAttemptOrHint = curTime;
 
     Exercises.userActivityLog.push(["hint-activity", "0", timeTaken]);
-
     if (!previewingItem && !localMode && !userExercise.readOnly &&
             !Exercises.currentCard.get("preview") && canAttempt) {
         // Don't do anything on success or failure; silently failing is ok here

--- a/interface.js
+++ b/interface.js
@@ -134,7 +134,11 @@ function problemTemplateRendered() {
     $("#answerform").submit(handleCheckAnswer);
     $("#questionform").submit(handleCheckAnswer);
     $("#skip-question-button").click(handleSkippedQuestion);
-
+    $("#jump-out").click(handleSkippedQuestion);
+    $("#watch-report-directly").click(handlegotoReport);
+    function handlegotoReport(){
+        location.href = location.href + '?exam_list_report=1';
+    }    
     // Hint button
     $("#hint").click(onHintButtonClicked);
 
@@ -363,14 +367,25 @@ function handleAttempt(data) {
                 .addClass("green");
         updateHintButtonText();
     }
-
-    $(Exercises).trigger("checkAnswer", {
+    if(skipped){
+         $(Exercises).trigger("skipAnswer", {
         correct: score.correct,
         card: Exercises.currentCard,
 
         // Determine if this attempt qualifies as fast completion
         fast: !localMode && userExercise.secondsPerFastProblem >= timeTaken
     });
+        
+    }
+    else{
+        $(Exercises).trigger("checkAnswer", {
+            correct: score.correct,
+            card: Exercises.currentCard,
+
+            // Determine if this attempt qualifies as fast completion
+            fast: !localMode && userExercise.secondsPerFastProblem >= timeTaken
+        });
+    }
 
     var curTime = new Date().getTime();
     var timeTaken = Math.round((curTime - lastAttemptOrHint) / 1000);

--- a/interface.js
+++ b/interface.js
@@ -414,6 +414,7 @@ function handleAttempt(data) {
         // Skip the server; just pretend we have success
         return false;
     }
+    var requestUrl = "problems/" + problemNum + "/attempt";
 
     if ((skipped || Exercises.examMode) && !Exercises.assessmentMode ) {
         // Skipping or examMode should pull up the next card immediately - but, if we're in
@@ -422,7 +423,7 @@ function handleAttempt(data) {
         $(Exercises).trigger("gotoNextProblem");
     }
     // Save the problem results to the server
-    var requestUrl = "problems/" + problemNum + "/attempt";
+    console.log(problemNum);
     request(requestUrl, attemptData).fail(function(xhr) {
         // Alert any listeners of the error before reload
         $(Exercises).trigger("attemptError", {userExercise: userExercise});
@@ -624,14 +625,13 @@ function handleJumpToHeaven(data) {
 
     return false;
 }
-function handleStopExam() {
-    console.log(Exercises.currentCard);
 
-    handleAttempt({skipped: true});
-    setTimeout(function(){
-    handleAttempt({skipped: true});
-    //do what you need here
-    }, 400);
+function handleStopExam() {
+    console.log(Exercises.incompleteStack.length);
+    cards_to_be_skipped = Exercises.incompleteStack.length;
+    for (i = 0; i < cards_to_be_skipped; i++){
+        handleAttempt({skipped: true});
+    }
 
    
     // setTimeout(function(){

--- a/interface.js
+++ b/interface.js
@@ -157,7 +157,7 @@ function problemTemplateRendered() {
 
     $("#watch-report-directly").click(function(e) {
         swal({
-            title:'<span style="font-size:16px;">小提醒：按下之後將中止這份評量，如評量為老師指派的任務，將無法重新進行。\n您確定要中止嗎？</span>',
+            title:'<span style="font-size:18px;">小提醒：按下之後將中止這份評量，如評量為老師指派的任務，將無法重新進行。\n您確定要中止嗎？</span>',
             imageUrl: '/images/warn.svg',
             imageWidth: 80,
             width: 420,
@@ -473,8 +473,9 @@ function handleAttempt(data) {
             );
         });
         return false;
+    }else{
+        return [return_problemNum,attemptData];
     }
-    return [return_problemNum,attemptData];
 }
 
 function onHintButtonClicked() {
@@ -708,7 +709,7 @@ function request(method, data) {
     attemptHintQueue.queue(function(next) {
         $.ajax(params).then(function(data, textStatus, jqXHR) {
 
-            //stuggling & attempt answer
+            // stuggling & attempt answer
             if (data.exerciseStates.struggling && "attemptCorrect" in data.actionResults){
                 if (!data.actionResults.attemptCorrect) {
                     var hint_disabled = $("#hint").attr("disabled");

--- a/interface.js
+++ b/interface.js
@@ -135,10 +135,24 @@ function problemTemplateRendered() {
     $("#questionform").submit(handleCheckAnswer);
     $("#skip-question-button").click(handleSkippedQuestion);
     $("#jump-out").click(handleSkippedQuestion);
-    $("#watch-report-directly").click(handleJumpToEnd);
+    //$("#watch-report-directly").click(handleJumpToEnd);
     function handlegotoReport(){
         location.href = location.href.split('?')[0] + '?exam_list_report=1';
-    }    
+    }
+    $("#watch-report-directly").click(function(e) {
+        swal({
+            title:'<span style="font-size:16px;">小提醒：按下之後將中止這份評量，如評量為老師指派的任務，將顯示您未完成任務。\n您確定要中止嗎？</span>',
+            imageUrl: '/images/warn.svg',
+            imageWidth: 80,
+            width: 420,
+            showCancelButton: true,
+            confirmButtonText: '是',
+            confirmButtonColor: '#ff6756',
+            cancelButtonText: '否',
+        }).then(function () {
+            handleJumpToEnd();
+        })
+    });    
     // Hint button
     $("#hint").click(onHintButtonClicked);
 

--- a/interface.js
+++ b/interface.js
@@ -135,7 +135,7 @@ function problemTemplateRendered() {
     $("#questionform").submit(handleCheckAnswer);
     $("#skip-question-button").click(handleSkippedQuestion);
     $("#jump-out").click(handleSkippedQuestion);
-    $("#watch-report-directly").click(handlegotoReport);
+    $("#watch-report-directly").click(handleStopExam);
     function handlegotoReport(){
         location.href = location.href.split('?')[0] + '?exam_list_report=1';
     }    
@@ -144,7 +144,8 @@ function problemTemplateRendered() {
 
     // Next question button
     $("#next-question-button").click(function() {
-        $(Exercises).trigger("gotoNextProblem");
+        $(Exercises).trigger("gotoNextProblem");        
+
         $("#raise-hand-button").prop('disabled', false);
 
         // Disable next question button until next time
@@ -457,6 +458,187 @@ function onHintButtonClicked() {
     } else if (framework === "khan-exercises") {
         $(Khan).trigger("showHint");
     }
+}
+
+function handleJumpToEnd(data){
+
+}
+function handleJumpToHeaven(data) {
+    attempTDataList = [];
+
+    var framework = Exercises.getCurrentFramework();
+    var skipped = data.skipped;
+    var score;
+
+    if (framework === "perseus") {
+        score = PerseusBridge.scoreInput();
+    } else if (framework === "khan-exercises") {
+        score = Khan.scoreInput();
+    }
+
+    if (!canAttempt) {
+        // Just don't allow further submissions once a correct answer or skip
+        // has been called or sometimes the server gets confused.
+        return false;
+    }
+
+    if (score.correct || skipped) {
+        // Once we receive a correct answer or a skip, that's it; further
+        // attempts are disallowed.
+        canAttempt = false;
+    }
+
+    Exercises.guessLog.push(score.guess);
+    Exercises.userActivityLog.push([
+            score.correct ? "correct-activity" : "incorrect-activity",
+            stringifiedGuess, timeTaken]);
+
+    if (score.correct || skipped || Exercises.examMode) {
+        $(Exercises).trigger("problemDone", {
+            card: Exercises.currentCard,
+            attempts: attempts
+        });
+    }
+
+    // Update interface corresponding to correctness,
+    // in examMode, we don't give feedback if it is correct or wrong
+    if (skipped || Exercises.assessmentMode || Exercises.examMode) {
+        disableCheckAnswer();
+        $("#check-answer-results > p").hide();
+    }
+
+    if (!hintsAreFree) {
+        hintsAreFree = true;
+        $(".hint-box")
+            .css("position", "relative")
+            .animate({top: -10}, 250)
+            .find(".info-box-header")
+                .slideUp(250)
+                .end()
+            .find("#hint")
+                .removeClass("orange")
+                .addClass("green");
+        updateHintButtonText();
+    }
+    if(skipped){
+         $(Exercises).trigger("skipAnswer", {
+        correct: null,
+        card: Exercises.currentCard,
+
+        // Determine if this attempt qualifies as fast completion
+        fast: !localMode && userExercise.secondsPerFastProblem >= timeTaken
+    });      
+    }
+    
+    var curTime = new Date().getTime();
+    var timeTaken = Math.round((curTime - lastAttemptOrHint) / 1000);
+    var stringifiedGuess = JSON.stringify(score.guess);
+    var attemptData = null;
+    if (!localMode) {
+        if(skipped){
+            attemptData = buildAttemptData(
+                null, ++attempts, stringifiedGuess, timeTaken, skipped);
+        }else
+        {
+            attemptData = buildAttemptData(
+                score.correct, ++attempts, stringifiedGuess, timeTaken, skipped);
+        }
+    }
+    lastAttemptOrHint = curTime;
+
+    if (localMode || Exercises.currentCard.get("preview")) {
+        // Skip the server; just pretend we have success
+        return false;
+    }
+
+    if ((skipped || Exercises.examMode) && !Exercises.assessmentMode ) {
+        // Skipping or examMode should pull up the next card immediately - but, if we're in
+        // assessment mode, we don't know what the next card will be yet, so
+        // wait for the special assessment mode triggers to fire instead.
+        $(Exercises).trigger("gotoNextProblem");
+    }
+
+    // Save the problem results to the server
+    
+    data = attemptData
+    var requestUrl = "problems/" + problemNum + "/attempt";
+    var apiBaseUrl = (Exercises.assessmentMode ?
+            "/api/v1/user/assessment/exercises" : "/api/v1/user/exercises");
+
+    var params = {
+        // Do a request to the server API
+        url: apiBaseUrl + "/" + userExercise.exerciseModel.name + "/" + requestUrl,
+        type: "POST",
+        data: data,
+        dataType: "json"
+    };
+
+    var deferred = $.Deferred();
+
+    attemptHintQueue.queue(function(next) {
+        $.ajax(params).then(function(data, textStatus, jqXHR) {
+            // Tell any listeners that we now have new userExercise data
+            $(Exercises).trigger("updateUserExercise", {
+                userExercise: data,
+                source: "serverResponse"
+            });
+        }, function(jqXHR, textStatus, errorThrown) {
+            // Execute passed error function first in case it wants different
+            // behavior depending upon the length of the request queue
+            // TODO(alpert): Huh? Don't think this matters.
+            deferred.reject(jqXHR, textStatus, errorThrown);
+
+            // Clear the queue so we don't spit out a bunch of queued up
+            // requests after the error
+            attemptHintQueue.clearQueue();
+        }).always(function() {
+            $(Exercises).trigger("apiRequestEnded");
+            next();
+        });
+    });
+    $(Exercises).trigger("apiRequestStarted");
+
+    // request(requestUrl, attemptData).fail(function(xhr) {
+    //     // Alert any listeners of the error before reload
+    //     $(Exercises).trigger("attemptError", {userExercise: userExercise});
+
+    //     if (xhr && xhr.readyState === 0) {
+    //         // This path gets called when there is a broken pipe during
+    //         // page unload- browser navigating away during ajax request
+    //         // See http://stackoverflow.com/a/1370383.
+    //         return;
+    //     }
+
+    //     // Error during submit. Disable the page and ask users to
+    //     // reload in an attempt to get updated data.
+
+    //     // Hide the page so users don't continue, then warn the user about the
+    //     // problem and encourage reloading the page
+    //     $("#problem-and-answer").css("visibility", "hidden");
+    //     $(Exercises).trigger("warning",
+    //             $._("這一個畫面過期了。請<a href='" + window.location.href +
+    //                 "'>重新整理</a>網頁。"
+    //                 )
+    //     );
+    // });
+
+    return false;
+}
+function handleStopExam() {
+    console.log(Exercises.currentCard);
+
+    handleAttempt({skipped: true});
+    setTimeout(function(){
+    handleAttempt({skipped: true});
+    //do what you need here
+    }, 400);
+
+   
+    // setTimeout(function(){
+    //     handleSkippedQuestion();
+    // //do what you need here
+    // }, 4000);
+
 }
 
 /**


### PR DESCRIPTION
中止考試
test server: 50
目的：

    1. 中止讓學生不用完成整個考試可以直接看到結果
    2. 跳題功能讓學生不用亂猜答案就能跳到下一題

測項


- 在評量專區進行exam
     
    - 按跳題
         1. 出現確認按鈕，第二次之後不會出現
         2. 會跳到下一題
         **3. 綠點"會"標色**
         4. 沒有動畫


    - 按中止考試
        1. 出現確認按鈕
        2. 跳出報告頁面
        **3. 跳過題目"會"變成綠色**
        **4. 考試的第一題不能跳過中止考試！**

    - 進行到一半離開考試，回到評量專區
        1. 出現繼續作答按鈕 

    - 看過報告頁面，回到評量專區    
       1. 出現看報告按鈕
    

點選該評量，將從頭作答，紀錄刷新

- 老師派exam任務

    行為與上列一致，但在任務列表中點選中止作答後，無法重新作答
    中止作答後，老師任務列表顯示已完成，任務報告顯示"＝"


    
需要特別測試exam類別

    - 包含多種exercise 的exam


身份路人 直接中止會render不出報告 （由擋第一題擋掉）
按到會不會洗掉ㄍreport（不會）
跳題現在在第幾題 （由綠點表示）
**mission派了 跑去評量專區做 （待測）
pretest mode 測試 （待測）**

